### PR TITLE
Update min Chrome version for Picture-in-Picture

### DIFF
--- a/src/data/policies.json
+++ b/src/data/policies.json
@@ -106,7 +106,7 @@
       { "rel": "feature-spec", "href": "https://wicg.github.io/picture-in-picture/" }
     ],
     "browserSupport": {
-      "chrome": { "minVersion": 74 }
+      "chrome": { "minVersion": 70 }
     }
   },
   {


### PR DESCRIPTION
Feature policy support for Picture-in-Picture has shipped in Chrome 70.