### PR TITLE
Do not prevent middle click in Firefox nor ctrl-click

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -74,7 +74,7 @@ export const pushState = (newRoutePath: string, newTitle?: string) => setState(n
 
 export const Link = (props: LinkProps) => {
   const clickHandler = (evt) => {
-    if (evt.shiftKey || evt.controlKey || evt.metaKey || evt.altKey) return
+    if (evt.shiftKey || evt.ctrlKey || evt.metaKey || evt.altKey || evt.nativeEvent.button === 1) return
     const route = config.routes.find(r => r.pattern.test(props.to))
     if (route) {
       evt.preventDefault()


### PR DESCRIPTION
Great resource Andrew, thanks for creating this!

I've noticed a small issue in Firefox: middle-clicking in Firefox prevents opening in new tab, because Firefox fires `click` for middle clicks (whereas Chrome stopped doing this in v55 in favor of `auxclick`).

Also `ctrlKey` was misspelled so it was preventing opening new tab in all browsers.